### PR TITLE
Fix multi username with same characters at beginning

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -155,10 +155,10 @@ for VARIABLE in $(env); do
 
         # add the user credentials to the vsftpd.passwd file
         entry="${VSFTPD_USER_NAME}:$(openssl passwd -1 "${VSFTPD_USER_PASS}")"
-        sedr="s~^${VSFTPD_USER_NAME}.*~${entry}~"
+        sedr="s~^${VSFTPD_USER_NAME}:.*~${entry}~"
 
         # check if the user exists already in the file
-        if [ ! -z "$(grep -G -i "^${VSFTPD_USER_NAME}" $PASSWD_FILE)" ]; then
+        if [ ! -z "$(grep -G -i "^${VSFTPD_USER_NAME}:" $PASSWD_FILE)" ]; then
             sed -i "${sedr}" $PASSWD_FILE
         else
             printf "%s:%s\n" "$VSFTPD_USER_NAME" "$(openssl passwd -1 "$VSFTPD_USER_PASS")" >> "$PASSWD_FILE"


### PR DESCRIPTION
Hello,

I have problem creating multiple users with the same begining username,

You can reproduce the bug:
services:
    vsftpd:
      container_name: vsftpd
      image: wildscamp/vsftpd
      hostname: vsftpd
      ports:
        - "21:21"
        - "30000-30009:30000-30009"
      environment:
        PASV_ADDRESS: 10.0.75.1
        PASV_MIN_PORT: 30000
        PASV_MAX_PORT: 30009
        VSFTPD_USER_1: 'www-data:ftp:33:'
        VSFTPD_USER_2: 'certs:certs:50:'
        VSFTPD_USER_3: 'mysql:mysql:999:'
        VSFTPD_USER_4: 'mysql2:mysql2:999:'
        VSFTPD_USER_5: 'mysql3:mysql3:999:'
        VSFTPD_USER_6: 'mysql4:mysql4:999:'
        VSFTPD_USER_7: 'mysql5:mysql5:999:'
        VSFTPD_USER_8: 'mysql6:mysql6:999:'

vsftpd.passwd:
mysql:$1$PGAZRRJE$3ahPPVCOElBdxDd.bCVdw/
certs:$1$Fpo6srXQ$ubgs2PYZa2QKlFnZhSu7/1
www-data:$1$KI8Uiz3r$Xo1bwY1RlKvXvCk68J/9S1
mysql:$1$PGAZRRJE$3ahPPVCOElBdxDd.bCVdw/
mysql:$1$PGAZRRJE$3ahPPVCOElBdxDd.bCVdw/
mysql:$1$PGAZRRJE$3ahPPVCOElBdxDd.bCVdw/
mysql:$1$PGAZRRJE$3ahPPVCOElBdxDd.bCVdw/
mysql:$1$PGAZRRJE$3ahPPVCOElBdxDd.bCVdw/
mysql4:$1$r3Wdz8q9$shmLXic.b5MkUQgLuj46g.
mysql5:$1$eKTCTirE$bVMIniqlkQu/rmmAPuk3B1
mysql2:$1$5gyNWjFk$Wj.rF0V7H03UEbP5C4NRv/
mysql3:$1$en2oTJLw$eYa5cfEbSTzHnZkJC60ot
